### PR TITLE
feat: Enhance OSDetector with enum types and better practices

### DIFF
--- a/src/main/java/utils/OSDetector.java
+++ b/src/main/java/utils/OSDetector.java
@@ -10,12 +10,28 @@ public class OSDetector {
     private static final String OS = System.getProperty("os.name").toLowerCase();
 
     /**
+     * Private constructor to prevent instantiation of utility class.
+     */
+    private OSDetector() {
+        throw new AssertionError("Utility class should not be instantiated");
+    }
+
+    /**
+     * Get the operating system name.
+     *
+     * @return The operating system name in lowercase.
+     */
+    public static String getOSName() {
+        return OS;
+    }
+
+    /**
      * Check if the operating system is Windows.
      *
      * @return {@code true} if the operating system is Windows, {@code false} otherwise.
      */
     public static boolean isWindows() {
-        return (OS.contains("win"));
+        return OS.contains("win");
     }
 
     /**
@@ -24,7 +40,7 @@ public class OSDetector {
      * @return {@code true} if the operating system is Mac, {@code false} otherwise.
      */
     public static boolean isMac() {
-        return (OS.contains("mac"));
+        return OS.contains("mac");
     }
 
     /**
@@ -33,6 +49,31 @@ public class OSDetector {
      * @return {@code true} if the operating system is Unix, {@code false} otherwise.
      */
     public static boolean isUnix() {
-        return (OS.contains("nix") || OS.contains("nux") || OS.contains("aix"));
+        return OS.contains("nix") || 
+               OS.contains("nux") || 
+               OS.contains("aix") || 
+               OS.contains("sunos");
     }
+
+    /**
+     * Get the operating system type.
+     *
+     * @return The {@link OSType} of the current system.
+     */
+    public static OSType getOSType() {
+        if (isWindows()) return OSType.WINDOWS;
+        if (isMac()) return OSType.MAC;
+        if (isUnix()) return OSType.UNIX;
+        return OSType.UNKNOWN;
+    }
+}
+
+/**
+ * Enum representing different operating system types.
+ */
+enum OSType {
+    WINDOWS,
+    MAC,
+    UNIX,
+    UNKNOWN
 }


### PR DESCRIPTION
- Add OSType enum for type-safe OS identification
- Prevent utility class instantiation with private constructor
- Add getOSName() and getOSType() methods
- Include Solaris detection in Unix checks
- Improve code readability and remove redundant parentheses
